### PR TITLE
fix: 从主进程注入 chii target，修复 QQNT 9.9.25+ 注入失败

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "scripts": {
         "patch": "npx patch-package chii",
-        "postinstall": "patch-package"
+        "postinstall": "patch-package && node scripts/postinstall.js"
     },
     "dependencies": {
         "chii": "1.15.4"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+// Linux 文件系统区分大小写
+// 上游 patch 将 chii_app.js 中的 application/ 改为 Application/
+// 但实际目录是小写的 application/，需要创建符号链接
+if (process.platform === "linux") {
+    const target = path.join(__dirname, "..", "node_modules", "chii", "public", "front_end", "panels", "Application");
+    if (!fs.existsSync(target)) {
+        fs.symlinkSync("application", target);
+        console.log("[postinstall] 已创建 Application -> application 符号链接");
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,61 +1,106 @@
 const chii = require("chii");
 const path = require("path");
-const net = require("net");
 const { BrowserWindow, ipcMain, session } = require("electron");
 const { slug } = require("../manifest.json");
 
+const PORT = 12580;
 
-// 获取空闲端口号
-const port = (() => {
-    const server = net.createServer().listen(0);
-    const { port } = server.address();
-    return server.close() && port;
-})();
-
-
-// 启动chii服务器
-chii.start({ port });
-
+console.log("[DevTools] 在端口", PORT, "上启动 chii");
+chii.start({ port: PORT });
 
 // 把端口传给渲染进程
-ipcMain.handle("mojinran.chii_devtools.ready", () => port);
+ipcMain.handle("mojinran.chii_devtools.ready", () => PORT);
 
+// 从主进程注入 chii target 脚本
+function injectTarget(webContents) {
+    webContents.executeJavaScript(`
+        if (!window.__chii) {
+            window.__chii = true;
+            var s = document.createElement('script');
+            s.src = 'http://localhost:${PORT}/target.js';
+            if (document.head) document.head.appendChild(s);
+            else document.addEventListener('DOMContentLoaded', () => document.head.appendChild(s));
+        }
+    `).catch(() => {});
+}
 
-// 打开DevTools
-async function openDevTools(window) {
-    const current_url = window.webContents.getURL();
-    const targets_url = `http://localhost:${port}/targets`;
-    const targets = await (await fetch(targets_url)).json();
-    for (const target of targets.targets.reverse()) {
-        if (target.url != current_url) continue;
-        const devtools_params = `?ws=localhost:${port}/client/LiteLoader?target=${target.id}`;
-        const devtools_url = `http://localhost:${port}/front_end/chii_app.html${devtools_params}`;
-        const devtools_window = new BrowserWindow({
-            autoHideMenuBar: true,
-            webPreferences: {
-                session: session.fromPath(path.join(LiteLoader.path.data, slug))
-            }
-        });
-        devtools_window.loadURL(devtools_url);
-        return devtools_window;
+// 根据 webContentsId 查找对应的调试目标
+async function findTargetForWindow(webContentsId) {
+    try {
+        const res = await fetch(`http://localhost:${PORT}/targets`);
+        const data = await res.json();
+        const targets = (data.targets || []).filter(t =>
+            !t.url.includes('chii_app.html') &&
+            !t.url.includes('hiddenWindow')
+        );
+        const match = targets.find(t => t.url.includes(`webcontentsid=${webContentsId}`));
+        if (match) return match;
+        const mainTarget = targets.find(t => t.url.includes('processGroupNS=createBlankWindow1'));
+        if (mainTarget) return mainTarget;
+        return targets[0] || null;
+    } catch (e) {
+        console.log("[DevTools] 查找目标失败:", e.message);
+        return null;
     }
 }
 
-
 // 创建窗口时触发
 exports.onBrowserWindowCreated = (window) => {
-    let devtools_window = null;
+    let devWin = null;
+
+    window.webContents.on("did-finish-load", () => {
+        injectTarget(window.webContents);
+
+        // 页面重载后自动重新连接 DevTools
+        if (devWin && !devWin.isDestroyed()) {
+            setTimeout(async () => {
+                const target = await findTargetForWindow(window.webContents.id);
+                if (target) {
+                    const url = `http://localhost:${PORT}/front_end/chii_app.html?ws=localhost:${PORT}/client/LiteLoader?target=${target.id}`;
+                    devWin.loadURL(url);
+                    console.log("[DevTools] 已自动重连目标:", target.id);
+                }
+            }, 1500);
+        }
+    });
+    setTimeout(() => injectTarget(window.webContents), 1000);
+
     window.webContents.on("before-input-event", async (event, input) => {
         if ((input.key == "F12" || (
             input.key == "I" && (process.platform === "darwin" ? input.meta : input.control) && input.shift)
         ) && input.type == "keyUp") {
-            if (devtools_window) {
-                devtools_window.close();
-                devtools_window = null;
+            if (devWin && !devWin.isDestroyed()) {
+                devWin.close();
+                devWin = null;
+                return;
             }
-            else {
-                devtools_window = await openDevTools(window);
-                devtools_window.on("closed", () => devtools_window = null);
+            try {
+                let target = await findTargetForWindow(window.webContents.id);
+                if (!target) {
+                    console.log("[DevTools] 未找到目标，重新注入...");
+                    injectTarget(window.webContents);
+                    await new Promise(r => setTimeout(r, 1500));
+                    target = await findTargetForWindow(window.webContents.id);
+                }
+                if (!target) {
+                    console.log("[DevTools] 仍未找到目标");
+                    return;
+                }
+                console.log("[DevTools] 连接目标:", target.id, target.url?.substring(0, 80));
+                const url = `http://localhost:${PORT}/front_end/chii_app.html?ws=localhost:${PORT}/client/LiteLoader?target=${target.id}`;
+                devWin = new BrowserWindow({
+                    title: "DevTools",
+                    autoHideMenuBar: true,
+                    width: 1280,
+                    height: 900,
+                    webPreferences: {
+                        session: session.fromPath(path.join(LiteLoader.path.data, slug))
+                    }
+                });
+                devWin.loadURL(url);
+                devWin.on("closed", () => devWin = null);
+            } catch (e) {
+                console.log("[DevTools] 错误:", e.message);
             }
         }
     });

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,17 +1,1 @@
-const { ipcRenderer } = require("electron");
-
-
-function injectChiiDevtools(port) {
-    const script = document.createElement("script");
-    script.defer = "defer";
-    script.src = `http://localhost:${port}/target.js`;
-    document.head.append(script);
-}
-
-
-ipcRenderer.invoke("mojinran.chii_devtools.ready").then(port => {
-    injectChiiDevtools(port);
-    navigation.addEventListener("navigatesuccess", () => {
-        injectChiiDevtools(port);
-    });
-});
+// 注入已由主进程处理，preload 不再需要


### PR DESCRIPTION
## 问题

在 QQNT 9.9.25+（build 42941）以上版本中，原有的 preload 注入方式失败，DevTools 无法打开。

根本原因有两个：
1. 部分窗口在 preload 执行时 `document.head` 为 null（#9 报告的问题，#10 的修复方案）
2. `app://` 协议阻止通过 DOM 加载 `http://localhost` 脚本

#10 通过在 preload 中对 `document.head` 进行空判断来解决第一个问题，但第二个问题仍然存在。

## 解决方案

将注入方式从 preload 改为主进程的 `webContents.executeJavaScript()`，同时解决了两个问题。preload 不再需要。

### 改动内容

**main.js（重写）：**
- 通过 `webContents.executeJavaScript()` 从主进程注入 chii target 脚本，绕过 CSP 和协议限制
- 注入脚本内部对 `document.head` 进行空判断，处理 DOMContentLoaded 前的情况
- 使用固定端口 12580 代替随机端口分配（便于外部调试工具连接）
- 通过 `webcontentsid` 匹配目标窗口，而不是 URL（`app://` URL 在 SPA 路由后不可靠）
- 过滤内部目标（chii_app.html、hiddenWindow）
- DevTools 窗口在页面重载后自动重新连接
- 找不到目标时自动重新注入并重试

**preload.js：**
- 清空（注入已完全由主进程处理）

**package.json：**
- postinstall 中添加 `ln -sf application .../panels/Application` 符号链接，修复 Linux 大小写敏感问题（上游 patch 将 `application/` 重命名为 `Application/`，但 Linux 文件系统区分大小写）

## 测试环境

| 组件 | 版本 |
|------|------|
| QQNT | 6.9.86-42941 |
| LiteLoader | 1.4.1 |
| Electron | 37.1.0 |
| 系统 | Arch Linux (kernel 6.19.11) |

已验证 F12 和 Ctrl+Shift+I 均可正常打开 DevTools 窗口，页面重载后自动重连。

Closes #9
Supersedes #10